### PR TITLE
Fixed path example

### DIFF
--- a/shacl-af/index.html
+++ b/shacl-af/index.html
@@ -294,6 +294,7 @@
 				<li>Added <a>orderBy expression</a>, <a>limit expression</a> and <a>offset expression</a></li>
 				<li>Added <a>minus expression</a></li>
 				<li>Added <a>SPARQL ASK expression</a> and <a>SPARQL SELECT expression</a></li>
+				<li>Fixed an example of sh:path expressions</li>
 			</ul>
 		</section>
 				
@@ -1202,7 +1203,7 @@ WHERE {
 <pre class="example-shapes" style="margin-top: 0">
 [  sh:path ex:firstName ] .
 
-[  sh:nodes ex:children ;
+[  sh:nodes [ sh:path ex:children ] ;
    sh:path rdfs:label ;
 ] .</pre>
 						</td>

--- a/shacl-compact-syntax/index.html
+++ b/shacl-compact-syntax/index.html
@@ -768,7 +768,7 @@ fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' 
             However, the same words may appear in Turtle and SPARQL documents.
             <dd></dd>
             <dt>File extension(s):</dt>
-            <dd>.shaclc</dd>
+            <dd>.shc, .shaclc</dd>
             <dt>Macintosh file type code(s):</dt>
             <dd>TEXT</dd>
           </dl>


### PR DESCRIPTION
This was incorrect because it would use ex:children as a value itself, while it should have used the values of ex:children.