### PR TITLE
Match template definition to usage

### DIFF
--- a/shacl-af/index.html
+++ b/shacl-af/index.html
@@ -601,7 +601,7 @@ ex:USCitizenShape
 					that gets mapped into the variable <code>country</code> in the corresponding SPARQL query to determine the resulting target nodes.
 				</p>
 				<pre class="example-shapes">
-ex:PeopleBornInCountryTarget
+ex:BornInCountryTarget
 	a sh:SPARQLTargetType ;
 	rdfs:subClassOf sh:Target ;
 	sh:labelTemplate "All persons born in {$country}" ;


### PR DESCRIPTION
Use `ex:BornInCountryTarget` in both places.